### PR TITLE
Send registration error to registrationError listener

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -118,7 +118,7 @@ export class PWAFirebaseMsgWeb extends WebPlugin implements PushNotificationsPlu
       await this.getFirebaseToken();
     }
     catch (ex) {
-      console.error('Unable to get Firebase token', ex);
+      this.notifyListeners('registrationError', ex);
     }
   }
 


### PR DESCRIPTION
Right now, if registration fails (for example, if the user denies permission), the registration error is caught inside the `register` function and there is not way to do something about it. In this pull request I am proposing to submit this error to the 'registrationError' listener instead, so that it can be handled in the user's code.